### PR TITLE
Se añadió UseWelcomePage a la raíz de OpenGov

### DIFF
--- a/OpenGov/Startup.cs
+++ b/OpenGov/Startup.cs
@@ -10,6 +10,7 @@ using GraphQL.Server.Ui.Playground;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
@@ -60,7 +61,7 @@ namespace OpenGov
             app.UseHttpsRedirection();
 
             app.UseMvc();
-
+            app.UseWelcomePage("/");
 
             IConfigurationSection padConfig = Configuration.GetSection("PAD");
             app.UsePoliticalAdministrativeDivision(


### PR DESCRIPTION
Se añadió UseWelcomePage a la raíz del OpenGov. De momento, no parece muy útil pero para desplegar el sitio en GKE y exponerlo mediante un Ingress, la raíz de la app web debe retornar 200, en caso contrario el balanceador retorna error 50x.